### PR TITLE
Add dev script and update docs

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,7 +6,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 In the project directory, you can run:
 
-### `npm start`
+### `npm run dev`
 
 Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in your browser.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "date-fns": "^3.6.0"
   },
   "scripts": {
+    "dev": "craco start",
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -30,7 +30,7 @@
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.
 
-      To begin the development, run `npm start` or `yarn start`.
+      To begin the development, run `npm run dev` or `yarn dev`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
         <a


### PR DESCRIPTION
## Summary
- add `dev` script to `package.json`
- document new script in README
- update development instructions in HTML

## Testing
- `python -m pytest -q` *(fails: FileNotFoundError for frontend .env)*

------
https://chatgpt.com/codex/tasks/task_e_687133006af88320a65e49effdc77fce